### PR TITLE
install.sh Improvements

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -61,10 +61,10 @@ fi
 
 
 echo 'Fetching theme archive'
-wget https://github.com/shvchk/${THEME}/archive/master.zip
+wget --output-file=/tmp/master.zip https://github.com/shvchk/${THEME}/archive/master.zip
 
 echo 'Unpacking theme'
-unzip master.zip
+unzip /tmp/master.zip -d /tmp/${THEME}-master
 
 if [[ "$LANG" != "English" ]]
 then
@@ -95,7 +95,7 @@ echo 'Adding theme to GRUB config'
 echo "GRUB_THEME=/boot/${GRUB_DIR}/themes/${THEME}/theme.txt" | sudo tee -a /etc/default/grub
 
 echo 'Removing theme installation files'
-rm -rf master.zip ${THEME}-master
+rm -rf /tmp/master.zip /tmp/${THEME}-master
 
 echo 'Updating GRUB'
 if [[ $UPDATE_GRUB ]]; then

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ if [ -e /etc/os-release ]; then
 
     elif [[ "$ID" =~ (centos|fedora|opensuse) || \
             "$ID_LIKE" =~ (fedora|rhel|suse) ]]; then
-            
+
         GRUB_DIR='grub2'
         UPDATE_GRUB='grub2-mkconfig -o /boot/grub2/grub.cfg'
     fi
@@ -84,11 +84,12 @@ then
               -e '/^\s+# '"${LANGS[$LANG]}"'$/{n;s/^(\s*)#\s*/\1/}' ${TMP_DIR}/theme.txt
 fi
 
-echo 'Creating GRUB themes directory'
-sudo mkdir -p /boot/${GRUB_DIR}/themes/${THEME}
+GRUB_THEME_DIR="/boot/${GRUB_DIR}/themes/${THEME}"
+echo "Creating GRUB themes directory: ${GRUB_THEME_DIR}"
+sudo mkdir -p ${GRUB_THEME_DIR}
 
 echo 'Copying theme to GRUB themes directory'
-sudo cp -r ${THEME}-master/* /boot/${GRUB_DIR}/themes/${THEME}
+sudo cp -r ${TMP_DIR}/* ${GRUB_THEME_DIR}
 
 echo 'Removing other themes from GRUB config'
 sudo sed -i '/^GRUB_THEME=/d' /etc/default/grub
@@ -103,7 +104,7 @@ echo 'Adding new line to GRUB config just in case' # optional
 echo | sudo tee -a /etc/default/grub
 
 echo 'Adding theme to GRUB config'
-echo "GRUB_THEME=/boot/${GRUB_DIR}/themes/${THEME}/theme.txt" | sudo tee -a /etc/default/grub
+echo "GRUB_THEME=${GRUB_THEME_DIR}/theme.txt" | sudo tee -a /etc/default/grub
 
 echo 'Removing temp. theme installation files'
 rm -rf ${TMP_FILE} ${TMP_DIR}

--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ wget -O ${TMP_FILE} https://github.com/shvchk/${THEME}/archive/master.zip
 
 if [ ! -f ${TMP_FILE} ]; then
     echo 'ERROR: Failed to download theme archive. Cannot continue.'
-    exit 1
+    exit 3
 fi
 
 echo "Unpacking theme to temp. directory ${TMP_DIR}"
@@ -74,7 +74,7 @@ unzip ${TMP_FILE}
 
 if [ ! -d ${TMP_DIR} ]; then
     echo 'ERROR: Failed to extract theme assets. Cannot continue.'
-    exit 2
+    exit 3
 fi
 
 if [[ "$LANG" != "English" ]]


### PR DESCRIPTION
When I first ran the installation script on my Ubuntu 18.04 desktop, the `wget` command downloaded the archive to `master` (not `master.zip`), so the following `unzip` command did not find the file. As a result, I ended up with an empty grub theme directory.

This PR adds a few checks to make sure that the archive is successfully downloaded and extracted before installing the theme.